### PR TITLE
Fix build system for windows targets

### DIFF
--- a/greenwave_monitor/src/greenwave_monitor.cpp
+++ b/greenwave_monitor/src/greenwave_monitor.cpp
@@ -456,7 +456,10 @@ GreenwaveMonitor::GetTimestampFromSerializedMessage(
   *(ns_byte_ptr + 3) = serialized_message_ptr->get_rcl_serialized_message().buffer[11];
 
   std::chrono::time_point<std::chrono::system_clock> timestamp(
-    std::chrono::seconds(timestamp_sec) + std::chrono::nanoseconds(timestamp_nanosec));
+    std::chrono::duration_cast<std::chrono::system_clock::duration>(
+        std::chrono::seconds(timestamp_sec) + std::chrono::nanoseconds(timestamp_nanosec)
+    )
+  );
   return timestamp;
 }
 

--- a/greenwave_monitor/src/greenwave_monitor.cpp
+++ b/greenwave_monitor/src/greenwave_monitor.cpp
@@ -457,7 +457,7 @@ GreenwaveMonitor::GetTimestampFromSerializedMessage(
 
   std::chrono::time_point<std::chrono::system_clock> timestamp(
     std::chrono::duration_cast<std::chrono::system_clock::duration>(
-        std::chrono::seconds(timestamp_sec) + std::chrono::nanoseconds(timestamp_nanosec)
+      std::chrono::seconds(timestamp_sec) + std::chrono::nanoseconds(timestamp_nanosec)
     )
   );
   return timestamp;


### PR DESCRIPTION
This will fix windows build systems. 

There is a stricter usage of Chrono with windows and MSVC. 

Thank you for all the work on this project. 

Let me know if there is anything else I can do if this does not fix it for you all.

I verified that this works on my windows machine.