### PR TITLE
Recommend APT package as default installation method. Update CI to use new Rolling.

### DIFF
--- a/.github/workflows/debian-packages.yml
+++ b/.github/workflows/debian-packages.yml
@@ -129,7 +129,11 @@ jobs:
         apt-get update -qq
         apt-get install -y curl gnupg lsb-release
         curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2.list
+        ROS_APT_REPOSITORY="ros2"
+        if [[ "${{ matrix.ros_distro }}" == "rolling" ]]; then
+          ROS_APT_REPOSITORY="ros2-testing"
+        fi
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/${ROS_APT_REPOSITORY}/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2.list
         apt-get update -qq
 
         # Install minimal ROS to get /opt/ros and basic infrastructure

--- a/.github/workflows/debian-packages.yml
+++ b/.github/workflows/debian-packages.yml
@@ -75,7 +75,7 @@ jobs:
           - ros_distro: kilted
             ubuntu_distro: noble
           - ros_distro: rolling
-            ubuntu_distro: noble
+            ubuntu_distro: resolute
 
     steps:
     - name: Checkout code
@@ -117,7 +117,7 @@ jobs:
           - ros_distro: kilted
             ubuntu_distro: noble
           - ros_distro: rolling
-            ubuntu_distro: noble
+            ubuntu_distro: resolute
 
     steps:
     - name: Setup ROS repository and install base ROS

--- a/.github/workflows/ros-tests.yml
+++ b/.github/workflows/ros-tests.yml
@@ -57,7 +57,7 @@ jobs:
           - ros_distro: kilted
             ubuntu_distro: noble
           - ros_distro: rolling
-            ubuntu_distro: noble
+            ubuntu_distro: resolute
 
     steps:
     - name: Checkout code

--- a/.github/workflows/ros-tests.yml
+++ b/.github/workflows/ros-tests.yml
@@ -92,7 +92,11 @@ jobs:
         apt-get update -qq
         apt-get install -y curl gnupg lsb-release
         curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2.list
+        ROS_APT_REPOSITORY="ros2"
+        if [[ "${{ matrix.ros_distro }}" == "rolling" ]]; then
+          ROS_APT_REPOSITORY="ros2-testing"
+        fi
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/${ROS_APT_REPOSITORY}/ubuntu $(lsb_release -cs) main" > /etc/apt/sources.list.d/ros2.list
         apt-get update -qq
         apt-get install -y python3-rosdep python3-colcon-common-extensions build-essential cmake git python3-pip ros-${{ matrix.ros_distro }}-ros-base
       shell: bash

--- a/README.md
+++ b/README.md
@@ -25,7 +25,14 @@ Greenwave monitor is a standalone package tested on Humble, Iron, Jazzy, Kilted,
 
 ## Installation
 
-From source:
+Recommended:
+
+```bash
+sudo apt install ros-${ROS_DISTRO}-greenwave-monitor
+```
+
+From source, for development:
+
 ```bash
 cd ros_ws/src
 git clone https://github.com/NVIDIA-ISAAC-ROS/greenwave_monitor.git

--- a/README.md
+++ b/README.md
@@ -27,8 +27,11 @@ Greenwave monitor is a standalone package tested on Humble, Iron, Jazzy, Kilted,
 
 Recommended:
 
+> **Note:** Make sure `ROS_DISTRO` is set to your ROS 2 distribution, for example by
+> running `source /opt/ros/<distro>/setup.bash`.
+
 ```bash
-sudo apt install ros-${ROS_DISTRO:-jazzy}-greenwave-monitor
+sudo apt install ros-${ROS_DISTRO}-greenwave-monitor
 ```
 
 From source, for development:

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Greenwave monitor is a standalone package tested on Humble, Iron, Jazzy, Kilted,
 Recommended:
 
 ```bash
-sudo apt install ros-${ROS_DISTRO}-greenwave-monitor
+sudo apt install ros-${ROS_DISTRO:-jazzy}-greenwave-monitor
 ```
 
 From source, for development:

--- a/scripts/build_debian_packages.sh
+++ b/scripts/build_debian_packages.sh
@@ -90,10 +90,16 @@ ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ >/etc/timezone
 apt-get update -qq
 apt-get install -y curl gnupg lsb-release
 
-if [ ! -f "/etc/apt/sources.list.d/ros2.list" ]; then
-	echo "Adding ROS 2 apt repository..."
+ROS_APT_REPOSITORY="ros2"
+if [[ "$ROS_DISTRO" == "rolling" ]]; then
+	ROS_APT_REPOSITORY="ros2-testing"
+fi
+ROS_APT_URL="http://packages.ros.org/$ROS_APT_REPOSITORY/ubuntu"
+
+if [ ! -f "/etc/apt/sources.list.d/ros2.list" ] || ! grep -q "$ROS_APT_URL" /etc/apt/sources.list.d/ros2.list; then
+	echo "Adding ROS 2 apt repository ($ROS_APT_REPOSITORY)..."
 	curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-	echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" >/etc/apt/sources.list.d/ros2.list
+	echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] $ROS_APT_URL $(lsb_release -cs) main" >/etc/apt/sources.list.d/ros2.list
 	apt-get update -qq
 else
 	echo "ROS 2 repository already configured"

--- a/scripts/build_debian_packages.sh
+++ b/scripts/build_debian_packages.sh
@@ -26,13 +26,14 @@
 #   ./scripts/build_debian_packages.sh                    # Uses defaults (humble/jammy)
 #   ./scripts/build_debian_packages.sh humble jammy      # ROS Humble on Ubuntu 22.04
 #   ./scripts/build_debian_packages.sh jazzy noble       # ROS Jazzy on Ubuntu 24.04
+#   ./scripts/build_debian_packages.sh rolling resolute  # ROS Rolling on Ubuntu 26.04
 #
 # Docker Usage (Recommended):
 #   docker run -it --rm -v $(pwd):/workspace -w /workspace \
 #     ubuntu:jammy ./scripts/build_debian_packages.sh humble jammy
 #
 # Supported combinations:
-#   humble/jammy, iron/jammy, jazzy/noble, kilted/noble, rolling/noble
+#   humble/jammy, iron/jammy, jazzy/noble, kilted/noble, rolling/resolute
 #
 # Output: Debian packages will be created in debian_packages/[ROS_DISTRO]/
 # Install: sudo apt install ./debian_packages/[ROS_DISTRO]/*.deb
@@ -59,10 +60,10 @@ esac
 
 # Validate Ubuntu distro
 case "$UBUNTU_DISTRO" in
-jammy | noble) ;;
+jammy | noble | resolute) ;;
 *)
 	echo "Error: Unsupported Ubuntu distro: $UBUNTU_DISTRO"
-	echo "Supported distros: jammy, noble"
+	echo "Supported distros: jammy, noble, resolute"
 	exit 1
 	;;
 esac
@@ -148,10 +149,12 @@ greenwave_monitor_interfaces:
   ubuntu:
     jammy: [ros-$ROS_DISTRO-greenwave-monitor-interfaces]
     noble: [ros-$ROS_DISTRO-greenwave-monitor-interfaces]
+    resolute: [ros-$ROS_DISTRO-greenwave-monitor-interfaces]
 greenwave_monitor:
   ubuntu:
     jammy: [ros-$ROS_DISTRO-greenwave-monitor]
     noble: [ros-$ROS_DISTRO-greenwave-monitor]
+    resolute: [ros-$ROS_DISTRO-greenwave-monitor]
 EOF
 
 # Setup rosdep

--- a/scripts/docker-test.sh
+++ b/scripts/docker-test.sh
@@ -40,7 +40,7 @@ kilted)
 	IMAGE="ros:kilted-ros-base-noble"
 	;;
 rolling)
-	IMAGE="ros:rolling-ros-base-noble"
+	IMAGE="ros:rolling-ros-base-resolute"
 	;;
 *)
 	echo "Unsupported ROS 2 distribution: $DISTRO"


### PR DESCRIPTION
The APT package was released but the README.md was never updated to recommend its use.

Also forced to update CI to use the newest Rolling which is on Ubuntu resolute and its apt packages are found on the ros2-testing apt server.